### PR TITLE
Grunt log error now display which file is having an issue when parsing.

### DIFF
--- a/tasks/json5_to_json.js
+++ b/tasks/json5_to_json.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
                       obj = JSON5.parse(json5);
                       json = JSON.stringify(obj, options.replacer, options.space);
                     } catch(e) {
-                      grunt.log.error(e);
+                      grunt.log.error(e + ' in ' src);
                       return;
                     }
 


### PR DESCRIPTION
Grunt log error now display which file is having an issue when parsing. Very useful when converting a folder containing hundreds of json5 files and knowing witch one are having issues. 
